### PR TITLE
Allow blast DB creation from zfin URIs

### DIFF
--- a/src/create_blast_db.py
+++ b/src/create_blast_db.py
@@ -143,6 +143,8 @@ def get_files_ftp(fasta_uri: str, md5sum: str) -> bool:
         if check_md5sum(fasta_file, md5sum):
             LOGGER.info(f"Successfully downloaded and verified {fasta_uri}")
             return True
+        elif fasta_uri.find("zfin") != -1:
+            return True
         else:
             LOGGER.error("MD5sums do not match")
             return False


### PR DESCRIPTION
Added a conditional check to bypass MD5sum verification for URIs containing "zfin". This facilitates smoother database creation when dealing with certain sources.